### PR TITLE
Check size of template history before removing last element

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.6.0"
+    version: "1.6.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/controllers/carplay_controller.dart
+++ b/lib/controllers/carplay_controller.dart
@@ -209,7 +209,9 @@ class FlutterCarplayController {
         topTemplate is CPInformationTemplate ||
         topTemplate is CPPointOfInterestTemplate) {
       if (topTemplate?.uniqueId == newTemplateId) {
-        if (templateHistory.isNotEmpty) {
+        // Removing the only available element would lead to a broken UI, so we must
+        // check if there are at least two elements.
+        if (templateHistory.length >= 2) {
           templateHistory.removeLast();
         }
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_carplay
 description: Flutter Apps are now on Apple CarPlay. This package aims to make it safe to use iPhone apps made with Flutter in the car by integrating with CarPlay.
-version: 1.6.0
+version: 1.6.1
 homepage: https://github.com/pradipaub36/flutter_carplay#readme
 repository: https://github.com/pradipaub36/flutter_carplay
 issue_tracker: https://github.com/oguzhnatly/flutter_carplay/issues


### PR DESCRIPTION
For some reason (probably a race condition when pushing a new screen and then popping it right away) the template history sometimes only contains one element (the root template). Removing the last element in this case would lead to a broken UI, so we must check if there are at least two elements.